### PR TITLE
Change GroupBuff Count to only track my own

### DIFF
--- a/modules/AuraTracker.lua
+++ b/modules/AuraTracker.lua
@@ -35,8 +35,8 @@ function tmwGetUnitAura(unit, spell, onlyMine)
 
 	if not spellLookup then return false end
 
-	for instanceId,_ in pairs(spellLookup) do 
-		if (instances[instanceId]) then
+	for instanceId, isMine ,_ in pairs(spellLookup) do 
+		if (instances[instanceId] and (isMine or not onlyMine)) then
 			return instances[instanceId]
 		end
 	end
@@ -69,7 +69,10 @@ TMW_ST.UnitAuras = {
 		else
 			return getUnitAura(unit, spell)
 		end
-	end
+	end,
+  getUnitAuras = function(unit, spell, onlyMine)
+    return tmwGetUnitAura(unit, spell, onlyMine)
+  end,
 }
 
 -- list of current roster memebers

--- a/modules/GroupBuffCount.lua
+++ b/modules/GroupBuffCount.lua
@@ -23,7 +23,7 @@ function getGroupBuffCount(spell, stop, countDead)
 		local name = i==0 and 'player' or prefix .. i
 		if countDead and UnitIsDeadOrGhost(name) then
 			count = count + 1
-		elseif TMW_ST.UnitAuras.getUnitAura(name, spell) then
+		elseif TMW_ST.UnitAuras.getUnitAuras(name, spell, true) then
 			count = count+1
 		end
 


### PR DESCRIPTION
Updated the AuraTracker to check if onlyMine. I'm not sure how to add a checkmark to the in-game UI part of this condition. But thought I'd share at least this incase it was something you'd want to implement. 